### PR TITLE
Allows a user to dynamically remove comparisons 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,6 +54,7 @@
         :phenRelatedGenes="overlappedPhenGenes"
         :batchNum="batchNum"
         :multiSampleVcf="multiSampleVcf"
+        @updateComparrisons="updateComparrisons"
         @zoomEvent="zoomFired"/>
 
     </div>
@@ -438,6 +439,9 @@
       },
       addToast(toast) {
         this.toasts.push(toast)
+      },
+      updateComparrisons(comparrisons) {
+        this.samples.comparrisons = comparrisons;
       }
     },
     watch: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,7 +54,7 @@
         :phenRelatedGenes="overlappedPhenGenes"
         :batchNum="batchNum"
         :multiSampleVcf="multiSampleVcf"
-        @updateComparrisons="updateComparrisons"
+        @updateComparisons="updateComparisons"
         @zoomEvent="zoomFired"/>
 
     </div>
@@ -112,7 +112,7 @@
             bai: '',
             svList: [],
           },
-          comparrisons: []
+          comparisons: []
         },
         toasts: [],
         multiSampleVcf: false
@@ -255,13 +255,13 @@
           let svListTemp = this.samples.proband.svList;
           this.samples.proband = samples.proband;
           this.samples.proband.svList = svListTemp;
-          this.samples.comparrisons = samples.comparrisons;
+          this.samples.comparisons = samples.comparisons;
           return;
         } else {
           this.samples.proband = samples.proband;
           this.loadData(this.multiSampleVcf);
         }
-        this.samples.comparrisons = samples.comparrisons;
+        this.samples.comparisons = samples.comparisons;
       },
       async getSVAssociations(variantBatch, build='hg38', source='refseq') {
 
@@ -440,8 +440,8 @@
       addToast(toast) {
         this.toasts.push(toast)
       },
-      updateComparrisons(comparrisons) {
-        this.samples.comparrisons = comparrisons;
+      updateComparisons(comparisons) {
+        this.samples.comparisons = comparisons;
       }
     },
     watch: {

--- a/src/components/LeftTracksSection.vue
+++ b/src/components/LeftTracksSection.vue
@@ -40,6 +40,7 @@
           :bands="bands"
           :chromosomes="chromosomes"
           :genes="genes"
+          @deleteTrack="removeTrack"
           @selectAreaEvent="selectAreaEventFired"/>
 
         <div id="linear-section-container" v-if="globalView === 'linear'" @dragover.prevent="handleDragOver" @drop="handleDrop">
@@ -63,6 +64,7 @@
             v-bind="chartData.props"
             @dragstart="handleDragStart(index, $event)"
             @selectAreaEvent="selectAreaEventFired"
+            @removeTrack="removeTrack(index - 1)"
             class="draggable-chart"
           />
         </div>
@@ -338,6 +340,11 @@
         return x;
       }
     },
+    removeTrack(trackIndex) {
+      let localSampleComparrisons = this.samples.comparrisons;
+      localSampleComparrisons.splice(trackIndex, 1);
+      this.$emit('updateComparrisons', localSampleComparrisons);
+    }
   },
   computed: {
     isGlobalView() {

--- a/src/components/LeftTracksSection.vue
+++ b/src/components/LeftTracksSection.vue
@@ -174,13 +174,13 @@
       }
     },
     async fetchSamples() {
-      let locComparrisons = this.samples.comparrisons;
+      let locComparisons = this.samples.comparisons;
       let locChartsData = this.chartsData.filter(chart => chart.props.title === 'Genes');
-      let locSamplesLists = new Array(this.samples.comparrisons.length);
-      let locSamplesTitles = new Array(this.samples.comparrisons.length);
+      let locSamplesLists = new Array(this.samples.comparisons.length);
+      let locSamplesTitles = new Array(this.samples.comparisons.length);
 
-      for (let i = 0; i < locComparrisons.length; i++) {
-        let sample = locComparrisons[i];
+      for (let i = 0; i < locComparisons.length; i++) {
+        let sample = locComparisons[i];
 
         let newSample = {
           component: 'LinearSvChartViz',
@@ -341,9 +341,9 @@
       }
     },
     removeTrack(trackIndex) {
-      let localSampleComparrisons = this.samples.comparrisons;
-      localSampleComparrisons.splice(trackIndex, 1);
-      this.$emit('updateComparrisons', localSampleComparrisons);
+      let localSampleComparisons = this.samples.comparisons;
+      localSampleComparisons.splice(trackIndex, 1);
+      this.$emit('updateComparisons', localSampleComparisons);
     }
   },
   computed: {

--- a/src/components/SelectDataSection.vue
+++ b/src/components/SelectDataSection.vue
@@ -17,7 +17,7 @@
                 @update-sample-files="addFileToWaygate"/>
 
             <SampleDataRow 
-                v-for="(sample, index) in samplesLocal.comparrisons" 
+                v-for="(sample, index) in samplesLocal.comparisons" 
                 :key="index" 
                 :sample="sample"
                 @close-row="removeRow(index)"
@@ -49,19 +49,19 @@
                 </fieldset>
 
                 <div class="label-input-wrapper" v-if="jointVcfHeaders.filter(id => id !== samplesLocal.proband.id).length > 0">
-                    <label for="comparrison-samples">Select Comparrison Samples</label>
-                    <select name="comparrison-samples" id="comparrisons" multiple v-model="selectedComparrisonSamples">
+                    <label for="comparison-samples">Select Comparison Samples</label>
+                    <select name="comparison-samples" id="comparisons" multiple v-model="selectedComparisonSamples">
                         <option v-for="header in jointVcfHeaders.filter(id => id !== samplesLocal.proband.id)" :key="header">{{header}}</option>
                     </select>
                 </div>
                 <div v-else><strong>Only one sample detected in:</strong> {{ jointVcfUrl }}</div>
 
-                <div class="sample-fieldset-wrapper" v-for="(sample, index) in selectedComparrisonSamples" :key="index">
+                <div class="sample-fieldset-wrapper" v-for="(sample, index) in selectedComparisonSamples" :key="index">
                     <fieldset>
                         <legend>ID: {{sample}}</legend>
                         <div class="label-input-wrapper">
-                            <label for="comparrison-name">Sample Name</label>
-                            <input type="text" id="comparrison-name" v-model="samplesLocal.comparrisons[index].name"/>
+                            <label for="comparison-name">Sample Name</label>
+                            <input type="text" id="comparison-name" v-model="samplesLocal.comparisons[index].name"/>
                         </div>
                     </fieldset>
                 </div>
@@ -97,7 +97,7 @@ export default {
             samplesFormat: 'individual',
             jointVcfHeaders: [],
             jointVcfUrl: '',
-            selectedComparrisonSamples: []
+            selectedComparisonSamples: []
         }
     },
     mounted () {
@@ -105,7 +105,7 @@ export default {
     },
     methods: {
         addNewSample () {
-            this.samplesLocal.comparrisons.push({
+            this.samplesLocal.comparisons.push({
                 name: '',
                 vcf: '',
                 tbi: '',
@@ -123,7 +123,7 @@ export default {
             this.$emit('toggle-show')
         },
         removeRow (index) {
-            this.samplesLocal.comparrisons.splice(index, 1)
+            this.samplesLocal.comparisons.splice(index, 1)
         },
         async startWaygate () {
             //if waygate is already active, don't start it again
@@ -162,8 +162,8 @@ export default {
             if (sampleName === this.samplesLocal.proband.name) {
                this.samplesLocal.proband[fileType] = uri
             } else {
-                //find the sample with this name in comparrisons
-                let sample = this.samplesLocal.comparrisons.find(sample => sample.name === sampleName)
+                //find the sample with this name in comparisons
+                let sample = this.samplesLocal.comparisons.find(sample => sample.name === sampleName)
                 sample[fileType] = uri
             }
         },
@@ -224,8 +224,8 @@ export default {
         }
     },
     watch: {
-        selectedComparrisonSamples (newVal) {
-            this.samplesLocal.comparrisons = newVal.map(sample => {
+        selectedComparisonSamples (newVal) {
+            this.samplesLocal.comparisons = newVal.map(sample => {
                 return {
                     name: sample,
                     vcf: this.jointVcfUrl,
@@ -241,7 +241,7 @@ export default {
             if (newVal !== oldVal) {
                 this.jointVcfHeaders = []
                 this.jointVcfUrl = ''
-                this.selectedComparrisonSamples = []
+                this.selectedComparisonSamples = []
             }
         }
     },

--- a/src/components/viz/linearSvChart.viz.vue
+++ b/src/components/viz/linearSvChart.viz.vue
@@ -1,6 +1,7 @@
 <template>
     <div ref="rootDraggableContainer" class="linear-sv-chart-wrapper">
       <p class="title" v-if="title">{{ title }}</p>
+      <div v-if="!isProband" class="remove-button" @click="emitRemoveTrack">x</div>
       <div v-if="!isProband" class="drag-handle" @mousedown="dragChartStart($event)" @mouseup="changeCursorToGrab($event)">. . .</div>
       <div :class="{hidden: isLoading}" ref="linearChartContainer" class="linear-sv-chart"></div>
       <div class="loading-message" v-if="isLoading">
@@ -94,6 +95,9 @@ export default {
         timeout = setTimeout(() => func.apply(this, args), delay);
       };
     },
+    emitRemoveTrack(){
+      this.$emit('removeTrack');
+    }
   },
   computed: {
     hasAllOptions(){
@@ -155,6 +159,25 @@ export default {
       &:hover
         box-shadow: 0px 0px 5px 0px #2A65B7
         background-color: #C1D1EA
+    .remove-button
+      position: absolute
+      top: 0px
+      left: -9px
+      font-size: 1.1em
+      cursor: pointer
+      color: #2A65B7
+      width: 20px
+      height: 20px
+      border-radius: 50%
+      border: 1px solid #2A65B7
+      display: flex
+      justify-content: center
+      align-items: center
+      line-height: 1em
+      box-shadow: 0px 0px 3px 0px #2A65B7
+      &:hover
+        color: red
+        border: 1px solid red
   .linear-sv-chart 
     height: 120px
     width: 100%

--- a/src/components/viz/svCircos.viz.vue
+++ b/src/components/viz/svCircos.viz.vue
@@ -13,7 +13,7 @@ export default {
   name: 'svCircos',
   components: {
   },
-  emits: ['selectAreaEvent'],
+  emits: ['selectAreaEvent', 'deleteTrack'],
   props: {
     svList: Array,
     probandName: {
@@ -80,6 +80,7 @@ export default {
         zoomCallback: this.emitZoomEvent,
         probandName: this.probandName,
         sampleNames: this.samplesTitles || [],
+        deleteTrackCallback: this.emitDeleteTrackEvent
       }
 
       if (this.genes) {
@@ -120,6 +121,9 @@ export default {
     },
     emitZoomEvent(zoomLevel) {
       this.$emit('selectAreaEvent', zoomLevel)
+    },
+    emitDeleteTrackEvent(trackIndex) {
+      this.$emit('deleteTrack', trackIndex)
     }
   },
   computed: {

--- a/src/d3/svCircos.js
+++ b/src/d3/svCircos.js
@@ -21,6 +21,8 @@ export default function svCircos(parentTag, refChromosomes, data=null, options=n
     let zoomZone = null;
     let zoomedSection = null;
 
+    let deleteTrackCallback = null;
+
     let { chromosomeAccumulatedMap, bpGenomeSize } = _genChromosomeAccumulatedMap(chromosomes);
     
     let originZoom = {
@@ -134,6 +136,11 @@ export default function svCircos(parentTag, refChromosomes, data=null, options=n
         //if we have an altCaller
         if (options.altCallerData) {
             altCallerData = options.altCallerData
+        }
+
+        //if we have a deleteTrackCallback
+        if (options.deleteTrackCallback) {
+            deleteTrackCallback = options.deleteTrackCallback
         }
     }
 
@@ -335,6 +342,48 @@ export default function svCircos(parentTag, refChromosomes, data=null, options=n
                 .attr('alignment-baseline', 'middle')
                 .text(sampleName)
                 .attr('font-size', '9px')
+                .raise();
+
+            //An x button to remove the track
+            let xButton = svg.append('g')
+                .attr('cursor', 'pointer')
+                .on('click', function (event, d) {
+                    //remove the track
+                    d3.select(this).remove();
+                });
+
+            xButton.append('circle')
+                .attr('cx', sampleLabelX - 23)
+                .attr('cy', sampleLabelY)
+                .attr('r', 6)
+                .attr('fill', 'red')
+                .attr('opacity', 0.5)
+                .on('mouseover', function (event, d) {
+                    d3.select(this).attr('opacity', 1);
+                })
+                .on('mouseout', function (event, d) {
+                    d3.select(this).attr('opacity', 0.5);
+                })
+                .on('click', function (event, d) {
+                    event.stopPropagation();
+                    event.preventDefault();
+                    //TODO: Call a callback to remove the track using the 'sampleName' as the key
+                    if (deleteTrackCallback) {
+                        let index = sampleNames.indexOf(sampleName);
+                        deleteTrackCallback(index);
+                    }
+                });
+
+            xButton.append('text')
+                .attr('x', sampleLabelX - 23)
+                .attr('y', sampleLabelY +1)
+                .attr('fill', 'white')
+                .attr('text-anchor', 'middle')
+                .attr('font-weight', 'bold')
+                .attr('alignment-baseline', 'middle')
+                .text('X')
+                .attr('font-size', '8px')
+                .style('pointer-events', 'none')
                 .raise();
             
             startRadius -= decNum;


### PR DESCRIPTION
Update spelling on comparisons

Allows the user to "remove" a track at will by clicking a button on the interface rather than having to re-select samples.