### PR TITLE
Improve gene chart

### DIFF
--- a/src/components/LeftTracksSection.vue
+++ b/src/components/LeftTracksSection.vue
@@ -272,6 +272,7 @@
 
       let chrom = focusedVariant.chromosome;
       let chromStart = this.chromosomeAccumulatedMap.get(chrom).start;
+      let chromEnd = this.chromosomeAccumulatedMap.get(chrom).end;
       let varStartAbs = parseInt(focusedVariant.start) + chromStart;
       let varEndAbs = parseInt(focusedVariant.end) + chromStart;
       let varSize = varEndAbs - varStartAbs;
@@ -288,10 +289,14 @@
 
       if (focusedStart < 0) {
           focusedStart = 0;
+      } else if (focusedStart < chromStart) {
+          focusedStart = chromStart;
       }
 
       if (focusedEnd >= this.genomeEnd) {
           focusedEnd = this.genomeEnd;
+      } else if (focusedEnd > chromEnd) {
+          focusedEnd = chromEnd;
       }
 
       let zoomedSection = {

--- a/src/components/viz/idiogramScaleBar.viz.vue
+++ b/src/components/viz/idiogramScaleBar.viz.vue
@@ -1,5 +1,7 @@
 <template>
-    <div class="idiogram-scale-bar-viz" ref="idiogramScaleContainer"></div>
+    <div class="idiogram-scale-bar-wrapper">
+        <div class="idiogram-scale-bar-viz" ref="idiogramScaleContainer"></div>
+    </div>
   </template>
   
   <script>
@@ -80,8 +82,11 @@
   </script>
   
   <style lang="sass">
+    .idiogram-scale-bar-wrapper
+        width: 100%
+        padding: 5px
     .idiogram-scale-bar-viz
         width: 100%
         height: 45px
-        padding: 0px 5px 
+        padding: 0px
   </style>

--- a/src/components/viz/linearGeneChart.viz.vue
+++ b/src/components/viz/linearGeneChart.viz.vue
@@ -153,5 +153,6 @@ export default {
     width: 100%
     box-sizing: border-box
     overflow: hidden
+    overflow-y: auto
 
 </style>

--- a/src/components/viz/linearGeneChart.viz.vue
+++ b/src/components/viz/linearGeneChart.viz.vue
@@ -143,11 +143,10 @@ export default {
       margin-bottom: 5px
       padding: 0px 2px
       background-color: #F8F8F8
-      writing-mode: vertical-rl
-      text-orientation: upright
+      pointer-events: none
       position: absolute
       left: -10px
-      top: 15%
+      top: 0px
   .linear-gene-chart 
     height: 120px
     width: 100%

--- a/src/components/viz/linearGeneChart.viz.vue
+++ b/src/components/viz/linearGeneChart.viz.vue
@@ -1,5 +1,5 @@
 <template>
-    <div draggable="true" class="linear-gene-chart-wrapper" ref="rootDraggableContainer">
+    <div class="linear-gene-chart-wrapper" ref="rootDraggableContainer">
       <p v-if="name">{{ name }}</p>
       <div ref="linearGeneChartContainer" class="linear-gene-chart"></div>
     </div>
@@ -148,6 +148,8 @@ export default {
       left: -10px
       top: 0px
   .linear-gene-chart 
+    padding: 0px
+    margin: 0px
     height: 120px
     width: 100%
     box-sizing: border-box

--- a/src/components/viz/linearGeneChart.viz.vue
+++ b/src/components/viz/linearGeneChart.viz.vue
@@ -155,5 +155,4 @@ export default {
     box-sizing: border-box
     overflow: hidden
     overflow-y: auto
-
 </style>

--- a/src/d3/idoigramScaleBar.d3.js
+++ b/src/d3/idoigramScaleBar.d3.js
@@ -1,4 +1,5 @@
 import * as d3 from 'd3';
+import { parse } from 'vue/compiler-sfc';
 
 export default function idoigramScaleBar(parentElementTag, refChromosomes, options) {
     let parentElement = d3.select(parentElementTag);
@@ -126,7 +127,14 @@ export default function idoigramScaleBar(parentElementTag, refChromosomes, optio
                     } else {
                         for (let [chr, chromosome] of chromosomeMap) {
                             if (d >= chromosome.start && d <= chromosome.end) {
-                                return `${chr}:${parseFloat(((d - chromosome.start) / 1000000).toFixed(3))}Mb`;
+                                let sizeInMb = parseFloat(((d - chromosome.start) / 1000000).toFixed(5));
+
+                                if (sizeInMb < 1) {
+                                    return `${parseFloat(((d - chromosome.start) / 1000).toFixed(3))}Kb`;
+                                }
+
+                                let num = parseFloat(((d - chromosome.start) / 1000000).toFixed(5));
+                                return `${num}Mb`;
                             }
                         }
                     }
@@ -134,7 +142,7 @@ export default function idoigramScaleBar(parentElementTag, refChromosomes, optio
             ))
         //tics need to be rotated slightly so they don't overlap
         .selectAll('text')
-        .attr('transform', 'rotate(6) translate(10, 0)')
+        .attr('transform', 'rotate(0) translate(6, 0)')
         .attr('fill', '#474747');
 
     svg.append('g')
@@ -341,6 +349,20 @@ export default function idoigramScaleBar(parentElementTag, refChromosomes, optio
                 .text(chr)
                 .attr('font-size', "14px")
                 .attr('fill', chromosomeColor);
+
+            let rangeLen = range[1] - range[0];
+            let chromosome1Length = chromosomeMap.get('1').end - chromosomeMap.get('1').start;
+
+            if (rangeLen <= chromosome1Length) {
+                //add the chromosome label at 10 10
+                chromosomeGroup.append('text')
+                    .attr('x', 10)
+                    .attr('y', 14)
+                    .text(chr)
+                    .attr('font-size', "18px")
+                    .attr('font-weight', 'bold')
+                    .attr('fill', chromosomeColor);
+            }
         };
     }
 

--- a/src/d3/idoigramScaleBar.d3.js
+++ b/src/d3/idoigramScaleBar.d3.js
@@ -235,7 +235,7 @@ export default function idoigramScaleBar(parentElementTag, refChromosomes, optio
                 chromosomeGroup.append('rect')
                     //class will be idiogram
                     .attr('class', 'upper-idiogram')
-                    .attr('x', 1)
+                    .attr('x', 0)
                     .attr('y', 0)
                     .attr('width', x(chromEndUpdated) - x(chromStartUpdated))
                     .attr('height', idioHeight)
@@ -248,7 +248,7 @@ export default function idoigramScaleBar(parentElementTag, refChromosomes, optio
                 chromosomeGroup.append('rect')
                     //class will be idiogram
                     .attr('class', 'upper-idiogram-parm')
-                    .attr('x', 1)
+                    .attr('x', 0)
                     .attr('y', 0)
                     .attr('width', function(){
                         //then return here the width which will be the scaled value from the start of the centromere to the end of the centromere

--- a/src/d3/linearGeneChart.d3.js
+++ b/src/d3/linearGeneChart.d3.js
@@ -89,7 +89,8 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
     const svg = d3.create('svg')
         .attr('viewBox', [0, 0, width, height])
         .attr('class', 'linear-gene-chart-d3')
-        .attr('width', width, height);
+        .attr('width', width)
+        .attr('height', height);
 
     let { chromosomeMap, genomeSize } = _genChromosomeAccumulatedMap(chromosomes);
 
@@ -126,6 +127,7 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
 
     _renderGenes([zoomedSelection.start, zoomedSelection.end])
 
+    //============================ INTERNAL FUNCTIONS ============================//
     function _genChromosomeAccumulatedMap(chromosomeList){
         let accumulatedBP = 0;
 
@@ -232,43 +234,44 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
 
                 let geneGroup = _createGene(xMap, idMap, gene, range, geneType, isLessThanOneChr);
 
-                let currentTrac = 1; 
-                let length = Object.keys(tracMap).length + 1;
-                let trackRange = Array.from({ length }, (_, i) => i + 1);
-
-                let measureSvg = d3.create('svg');
-                parentElement.appendChild(measureSvg.node());
-
                 let label = geneGroup.select('.gene-label');
                 let mTextWidth = 0;
+
                 if (label.node()) {
+                    let measureSvg = d3.create('svg');
+                    parentElement.appendChild(measureSvg.node());
+
                     let measureText = measureSvg.node().appendChild(label.node().cloneNode(true));
                     mTextWidth = measureText.getBBox().width;
                     measureSvg.remove();
                 }
 
-                for (let x of trackRange) {
-                    if (tracMap[x] && ((startX - mTextWidth) > tracMap[x])) {
-                        tracMap[x] = endX;
-                        currentTrac = x;
-                        break;
-                    } else if (tracMap[x] && ((startX - mTextWidth) < tracMap[x])) {
-                        continue;
-                    }
+                let currentTrac = 1; 
+                let length = Object.keys(tracMap).length + 1;
+                let trackRange = Array.from({ length }, (_, i) => i + 1);
 
+                for (let x of trackRange) {
                     if (!tracMap[x]) {
                         tracMap[x] = endX;
                         currentTrac = x;
                         break;
                     }
+
+                    if ((startX - mTextWidth) > tracMap[x]) {
+                        tracMap[x] = endX;
+                        currentTrac = x;
+                        break;
+                    } else if ((startX - mTextWidth) < tracMap[x]) {
+                        continue;
+                    }
                 }
 
                 let translateY = (currentTrac - 1) * 9;
 
-                if (translateY > height) {
+                if (translateY >= height) {
                     height += 9;
                     svg.attr('viewBox', [0, 0, width, height])
-                        .attr('width', width, height);
+                        .attr('height', height);
                 }
 
                 geneGroup.attr('transform', `translate(${startX - margin.left}, ${translateY + 25})`);
@@ -413,13 +416,6 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
             let mTextWidth = measureText.node().getBBox().width;
             measureSvg.remove();
 
-            let rect = geneGroup.append('rect')
-                .attr('x', 0 + margin.left)
-                .attr('width', mTextWidth)
-                .attr('height', 8)
-                .attr('fill', 'white')
-                .attr('fill-opacity', 0.85);
-
             //add the labels
             let text = geneGroup.append('text')
                 .attr('class', 'gene-label')
@@ -430,7 +426,7 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                 .attr('fill', 'red');
 
             text.attr('transform', `translate(-${mTextWidth}, 0)`);
-            rect.attr('transform', `translate(-${mTextWidth}, -${4})`);
+
             return geneGroup;
         } else if (geneType == 'phenRelatedGene') {
             //Phen related genes
@@ -464,13 +460,6 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                 let mTextWidth = measureText.node().getBBox().width;
                 measureSvg.remove();
 
-                let rect = geneGroup.append('rect')
-                    .attr('x', 0 + margin.left)
-                    .attr('width', mTextWidth)
-                    .attr('height', 8)
-                    .attr('fill', 'white')
-                    .attr('fill-opacity', 0.85);
-
                 //add the labels
                 let text = geneGroup.append('text')
                     .attr('class', 'gene-label')
@@ -481,7 +470,6 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                     .attr('fill', 'blue');
 
                 text.attr('transform', `translate(-${mTextWidth}, 0)`);
-                rect.attr('transform', `translate(-${mTextWidth}, -${4})`);
             }
 
             return geneGroup;

--- a/src/d3/linearGeneChart.d3.js
+++ b/src/d3/linearGeneChart.d3.js
@@ -396,14 +396,14 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                 .attr('class', 'gene-rect')
                 .attr('width', function() {
                     if (endX - startX < 1) {
-                        return 2;
+                        return 1;
                     }
                     return endX - startX;
                 })
                 .attr('height', 4)
                 .attr('fill', 'red')
                 .attr('rx', function() {
-                    if (endX - startX < 1) {
+                    if (endX - startX < 3) {
                         return 0;
                     }
                     return 1; 
@@ -445,14 +445,14 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                 .attr('class', 'gene-rect')
                 .attr('width', function() {
                     if (endX - startX < 1) {
-                        return 2;
+                        return 1;
                     }
                     return endX - startX;
                 })
                 .attr('height', 4)
                 .attr('fill', 'blue')
                 attr('rx', function() {
-                    if (endX - startX < 1) {
+                    if (endX - startX < 3) {
                         return 0;
                     }
                     return 1; 
@@ -501,14 +501,14 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                 .attr('class', 'gene-rect')
                 .attr('width', function() {
                     if (endX - startX < 1) {
-                        return 2;
+                        return 1;
                     }
                     return endX - startX;
                 })
                 .attr('height', 4)
                 .attr('fill', 'black')
                 .attr('rx', function() {
-                    if (endX - startX < 1) {
+                    if (endX - startX < 3) {
                         return 0;
                     }
                     return 1; 

--- a/src/d3/linearGeneChart.d3.js
+++ b/src/d3/linearGeneChart.d3.js
@@ -149,79 +149,65 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
     function _renderGenes(range) {
         //grab all the point-group groups and remove them before rendering the new ones
         svg.selectAll('.point-group').remove();
+        svg.selectAll('.point-group-phenrelated').remove();
+        svg.selectAll('.point-group-geneofinterest').remove();
 
-        //========== WHOLE GENOME LEVEL ==========//
-        if (range[0] == 0 && range[1] == genomeSize) {
-            if (phenRelatedGenes && phenRelatedGenes.length > 0) {
-                _renderPhenRelatedGenes(phenRelatedGenes, chromosomeMap, range, svg, genesOfInterest);
-            }
-            //If there are genes of interest then we want to render them
-            if (genesOfInterest && genesOfInterest.length > 0) {
-                _renderGenesOfInterest(genesOfInterest, chromosomeMap, range, svg);
-            }
+        let isWholeGenome = range[0] == 0 && range[1] == genomeSize;
+        let isLessThanOneChr = range[1] - range[0] <= chromosomeMap.get('1').end;
 
-            //if there are no genes of interest or phen related genes then we want to just put a text that says "Zoom in to see genes"
-            if ((!phenRelatedGenes || phenRelatedGenes.length == 0) && (!genesOfInterest || genesOfInterest.length == 0)) {
-                svg.append('text')
-                    .attr('x', width/2 - 80)
-                    .attr('y', height/2)
-                    .text('Select an area to view genes')
-                    .attr('font-size', '15px')
-                    .attr('fill', '#2A65B7')
-                    .attr('font-style', 'italic');
-            }
+        //if we are rendering the whole genome and don't have any GOI or phenRelatedGenes, return early
+        if (isWholeGenome && (!phenRelatedGenes || phenRelatedGenes.length == 0) && (!genesOfInterest || genesOfInterest.length == 0)) {
+            svg.append('text')
+                .attr('x', width/2 - 80)
+                .attr('y', height/2)
+                .text('Select an area to view genes')
+                .attr('font-size', '15px')
+                .attr('fill', '#2A65B7')
+                .attr('font-style', 'italic');
             return;
         } 
 
-        //========== ZOOMED LEVEL ==========//
         let localGenes = JSON.parse(JSON.stringify(genes));
-        //Remove the phen related genes and genes of interest from the localGenes
-        if (genesOfInterest && genesOfInterest.length > 0) {
-            for (let gene of genesOfInterest) {
-                delete localGenes[gene.gene_symbol];
-            }
-        }
-        if (phenRelatedGenes && phenRelatedGenes.length > 0) {
-            for (let gene of phenRelatedGenes) {
-                delete localGenes[gene.gene_symbol];
-            }
-        }
 
         let tracMap = {
-            2: false,
+            1: false,
         };
 
         let genesMap = {};
-        //iterate over the genes
         for (let gene of Object.values(localGenes)) {
-            //get the chromosome and position
+            
+            let geneType = _determineGeneType(gene, genesOfInterest, phenRelatedGenes);
+
+            //if we are rendering the whole genome and the gene is a normal gene then we skip it
+            if (isWholeGenome && geneType == 'normal') {
+                continue;
+            }
+
             let chr = gene.chr.replace('chr', '');
             
             let start = gene.start;
             let end = gene.end;
 
-            //get the corresponding chromosome from the accumulated map
             let chromosome = chromosomeMap.get(chr);
             if (!chromosome) {
                 continue;
             }
+
             let absoluteStart = chromosome.start + start;
             let absoluteEnd = chromosome.start + end;
 
             let startUpdated = absoluteStart;
             let endUpdated = absoluteEnd;
 
-            let startX = null; //no sense in setting these yet
+            let startX = null;
             let endX = null;
 
             //check and see if the gene is in the zoomed selection
             let newStartEnd = _getStartEndForRange(absoluteStart, absoluteEnd, range);
 
             if (!newStartEnd) {
-                //if we get nothing back we dont render this gene at all
                 continue;
             } else {
-                //we will either get back the truncated start/ends or the original start/ends depending on if the gene is in the range
                 startUpdated = newStartEnd.start;
                 endUpdated = newStartEnd.end;
 
@@ -229,7 +215,7 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                 endX = x(endUpdated);
             }
 
-            //add the gene to the map with the absolute start and end as the key "absoluteStart-absoluteEnd"
+            //add the gene to the map if it doesn't exist
             if (!genesMap[`${absoluteStart}-${absoluteEnd}`]) {
                 genesMap[`${absoluteStart}-${absoluteEnd}`] = [gene];
 
@@ -244,51 +230,54 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                     'endX': endX
                 };
 
-                let geneGroup = _createNormalGene(xMap, idMap, gene, range);
+                let geneGroup = _createGene(xMap, idMap, gene, range, geneType, isLessThanOneChr);
 
                 let currentTrac = 1; 
                 let length = Object.keys(tracMap).length + 1;
                 let trackRange = Array.from({ length }, (_, i) => i + 1);
 
+                let measureSvg = d3.create('svg');
+                parentElement.appendChild(measureSvg.node());
+
+                let label = geneGroup.select('.gene-label');
+                let mTextWidth = 0;
+                if (label.node()) {
+                    let measureText = measureSvg.node().appendChild(label.node().cloneNode(true));
+                    mTextWidth = measureText.getBBox().width;
+                    measureSvg.remove();
+                }
+
                 for (let x of trackRange) {
-                    if (tracMap[x] != false && (startX > tracMap[x])) {
+                    if (tracMap[x] && ((startX - mTextWidth) > tracMap[x])) {
                         tracMap[x] = endX;
                         currentTrac = x;
                         break;
-                    } else if (tracMap[x] != false && (startX < tracMap[x])) {
+                    } else if (tracMap[x] && ((startX - mTextWidth) < tracMap[x])) {
                         continue;
                     }
 
-                    if (tracMap[x] == false) {
+                    if (!tracMap[x]) {
                         tracMap[x] = endX;
                         currentTrac = x;
                         break;
                     }
                 }
 
-                let translateY = (currentTrac - 1) * 8;
+                let translateY = (currentTrac - 1) * 9;
 
-                if (translateY >= height) {
-                    height += 8;
+                if (translateY > height) {
+                    height += 9;
                     svg.attr('viewBox', [0, 0, width, height])
                         .attr('width', width, height);
                 }
 
-                geneGroup.attr('transform', `translate(${startX - margin.left}, ${translateY + 30})`);
+                geneGroup.attr('transform', `translate(${startX - margin.left}, ${translateY + 25})`);
 
                 svg.append(() => geneGroup.node()); //append the gene group to the svg
             } else {
                 //dont render the gene if it already exists
                 genesMap[`${absoluteStart}-${absoluteEnd}`].push(gene);
             }
-        }
-    
-        //========== AFTER NORMAL GENES WHEN ZOOMED RENDER OTHERS ==========//
-        if (phenRelatedGenes && phenRelatedGenes.length > 0) {
-            _renderPhenRelatedGenes(phenRelatedGenes, chromosomeMap, range, svg, genesOfInterest);
-        }
-        if (genesOfInterest && genesOfInterest.length > 0) {
-            _renderGenesOfInterest(genesOfInterest, chromosomeMap, range, svg);
         }
     }
 
@@ -341,259 +330,6 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
         }
     }
 
-    function _renderPhenRelatedGenes(genes, chromosomeMap, range, svg, genesOfInterest=null) {
-        //Remove all the point-group-phenrelated groups before rendering the new ones
-        svg.selectAll('.point-group-phenrelated').remove();
-        
-        let tracMap = {
-            1: false,
-        };
-
-        let genesMap = {};
-
-        //iterate over the genes
-        for (let gene of Object.values(genes)) {
-            //get the chromosome and position
-            let chr = gene.chr.replace('chr', '');
-            
-            let start = gene.start;
-            let end = gene.end;
-
-            //get the corresponding chromosome from the accumulated map
-            let chromosome = chromosomeMap.get(chr);
-            if (!chromosome) {
-                continue;
-            }
-            let absoluteStart = chromosome.start + start;
-            let absoluteEnd = chromosome.start + end;
-
-            let startUpdated = absoluteStart;
-            let endUpdated = absoluteEnd;
-
-            let startX = null; //no sense in setting these yet
-            let endX = null;
-
-            //check and see if the point of interest is in the zoomed selection
-            let newStartEnd = _getStartEndForRange(absoluteStart, absoluteEnd, range);
-            
-            if (!newStartEnd) {
-                //if we get nothing back we dont render this point of interest at all
-                continue;
-            } else {
-                //we will either get back the truncated start/ends or the original start/ends depending on if the point of interest is in the range
-                startUpdated = newStartEnd.start;
-                endUpdated = newStartEnd.end;
-
-                startX = x(startUpdated);
-                endX = x(endUpdated);
-            }
-
-            //add the point of interest to the map with the absolute start and end as the key "absoluteStart-absoluteEnd"
-            if (!genesMap[`${absoluteStart}-${absoluteEnd}`]) {
-                genesMap[`${absoluteStart}-${absoluteEnd}`] = [gene];
-
-                //create a new group for this point of interest
-                let pointGroup = svg.append('g')
-                    .attr('transform', `translate(${startX - margin.left}, 30)`)
-                    .attr('class', 'point-group-phenrelated')
-                    .attr('id', `poi-${chr}-${start}-${end}-group`);
-
-                let currentTrac = 0;
-
-                let length = Object.keys(tracMap).length + 1;
-                let trackRange = Array.from({ length }, (_, i) => i + 1);
-                for (let x of trackRange) {
-                    if (tracMap[x] && (startX > tracMap[x])) {
-                        tracMap[x] = endX;
-                        currentTrac = x;
-                        break;
-                    } else if (tracMap[x] && (startX < tracMap[x])) {
-                        continue;
-                    }
-
-                    if (!tracMap[x]) {
-                        tracMap[x] = endX;
-                        currentTrac = x;
-                        break;
-                    }
-                }
-
-                let translateY = (currentTrac - 1) * 8;
-                //If the translate Y is > height we need to increase the height by (8px)
-                if (translateY > height) {
-                    height += 8;
-                    svg.attr('viewBox', [0, 0, width, height])
-                        .attr('width', width, height);
-                }
-
-                pointGroup.append('rect')
-                    .attr('x', 0 + margin.left)
-                    .attr('width', function() {
-                        //if the block is too small to see make it 2 pixels wide
-                        if (endX - startX < 1) {
-                            return 1;
-                        }
-                        return endX - startX;
-                    })
-                    .attr('transform', `translate(0, ${translateY})`)
-                    .attr('height', 2)
-                    .attr('fill', 'blue')
-                    .attr('fill-opacity', 0.75);
-                
-                //we dont show labels for these at the global level
-                if (range[0] !== 0 && range[1] !== genomeSize) {
-                    //add a rectangle that is the width of the text
-                    let textWidth = (gene.gene_symbol.length * 5) + 1;
-
-                    let rect = pointGroup.append('rect')
-                        .attr('x', 0 + margin.left)
-                        .attr('width', textWidth)
-                        .attr('height', 8)
-                        .attr('fill', 'white')
-                        .attr('fill-opacity', 0.85);
-
-                    //add the labels
-                    let text = pointGroup.append('text')
-                        .attr('x', 0 + margin.left)
-                        .attr('y', 4)
-                        .text(gene.gene_symbol)
-                        .attr('font-size', "8px")
-                        .attr('fill', 'blue');
-
-                    text.attr('transform', `translate(-${textWidth}, ${translateY})`);
-                    rect.attr('transform', `translate(-${textWidth}, ${translateY - 4})`);
-                }
-
-
-            } else {
-                //dont render the point of interest if it already exists
-                genesMap[`${absoluteStart}-${absoluteEnd}`].push(gene);
-            }
-        }
-    }
-
-    function _renderGenesOfInterest(genes, chromosomeMap, range, svg) {
-        //Remove all the point-group-geneofinterest groups before rendering the new ones
-        svg.selectAll('.point-group-geneofinterest').remove();
-
-        let tracMap = {
-            1: false,
-        };
-
-        let genesMap = {};
-
-        //iterate over the genes
-        for (let gene of Object.values(genes)) {
-            if (!gene || !gene.chr || !gene.start || !gene.end) {
-                continue;
-            }
-
-            //get the chromosome and position
-            let chr = gene.chr.replace('chr', '');
-            
-            let start = gene.start;
-            let end = gene.end;
-
-            //get the corresponding chromosome from the accumulated map
-            let chromosome = chromosomeMap.get(chr);
-            if (!chromosome) {
-                continue;
-            }
-            let absoluteStart = chromosome.start + start;
-            let absoluteEnd = chromosome.start + end;
-
-            let startUpdated = absoluteStart;
-            let endUpdated = absoluteEnd;
-
-            let startX = null; //no sense in setting these yet
-            let endX = null;
-
-            //check and see if the point of interest is in the zoomed selection
-            let newStartEnd = _getStartEndForRange(absoluteStart, absoluteEnd, range);
-
-            if (!newStartEnd) {
-                //if we get nothing back we dont render this point of interest at all
-                continue;
-            } else {
-                //we will either get back the truncated start/ends or the original start/ends depending on if the point of interest is in the range
-                startUpdated = newStartEnd.start;
-                endUpdated = newStartEnd.end;
-
-                startX = x(startUpdated);
-                endX = x(endUpdated);
-            }
-
-            //add the point of interest to the map with the absolute start and end as the key "absoluteStart-absoluteEnd"
-            if (!genesMap[`${absoluteStart}-${absoluteEnd}`]) {
-                genesMap[`${absoluteStart}-${absoluteEnd}`] = [gene];
-
-                //create a new group for this point of interest
-                let pointGroup = svg.append('g')
-                    .attr('transform', `translate(${startX - margin.left}, 30)`)
-                    .attr('class', 'point-group-geneofinterest')
-                    .attr('id', `poi-${chr}-${start}-${end}-group`);
-
-                let currentTrac = 0;
-
-                let length = Object.keys(tracMap).length + 1;
-                let trackRange = Array.from({ length }, (_, i) => i + 1);
-
-                for (let x of trackRange) {
-                    if (tracMap[x] && (startX > tracMap[x])) {
-                        tracMap[x] = endX;
-                        currentTrac = x;
-                        break;
-                    } else if (tracMap[x] && (startX < tracMap[x])) {
-                        continue;
-                    }
-
-                    if (!tracMap[x]) {
-                        tracMap[x] = endX;
-                        currentTrac = x;
-                        break;
-                    }
-                }
-
-                let translateY = (currentTrac - 1) * 8;
-
-                //TODO: This is never happening. Need to figure out why
-                if ((translateY + 10) >= height) {
-                    height += 9;
-                    svg.attr('viewBox', [0, 0, width, height])
-                        .attr('width', width, height);
-                }
-
-                pointGroup.append('rect')
-                    .attr('x', 0 + margin.left)
-                    .attr('width', function() {
-                        //if the block is too small to see make it 2 pixels wide
-                        if (endX - startX < 1) {
-                            return 1;
-                        }
-                        return endX - startX;
-                    })
-                    .attr('transform', `translate(0, ${translateY})`)
-                    .attr('height', 2)
-                    .attr('fill', 'red');
-                
-                let textWidth = (gene.gene_symbol.length * 5) + 1;
-
-                //add the labels
-                let text = pointGroup.append('text')
-                    .attr('x', 0 + margin.left)
-                    .attr('y', 4)
-                    .text(gene.gene_symbol)
-                    .attr('font-size', "8px")
-                    .attr('fill', 'red')
-                    .attr('transform', `translate(-${textWidth}, ${translateY})`);
-
-            } else {
-                //dont render the point of interest if it already exists
-                genesMap[`${absoluteStart}-${absoluteEnd}`].push(gene);
-            }
-        }
-    }
-
     function _getStartEndForRange(start, end, range) {
         let st = start;
         let en = end;
@@ -613,44 +349,57 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
         return {start: st, end: en};
     }
 
-    function _createNormalGene(xMap, idMap, gene, range) {
+    function _determineGeneType(gene, genesOfInterest, phenRelatedGenes) {
+        let type = 'normal';
+        if (genesOfInterest && genesOfInterest.length > 0) {
+            for (let geneOfInterest of genesOfInterest) {
+                if (gene.gene_symbol == geneOfInterest.gene_symbol) {
+                    type = 'geneOfInterest';
+                    return type;
+                }
+            }
+        }
+        
+        if (phenRelatedGenes && phenRelatedGenes.length > 0) {
+            for (let phenRelatedGene of phenRelatedGenes) {
+                if (gene.gene_symbol == phenRelatedGene.gene_symbol) {
+                    type = 'phenRelatedGene';
+                    return type;
+                }
+            }
+        }
+
+        return type;
+    }
+
+    function _createGene(xMap, idMap, gene, range, geneType, isLessThanOneChr) {
         let chr = idMap.chr;
         let start = idMap.start;
         let end = idMap.end;
 
         let startX = xMap.startX;
         let endX = xMap.endX;
+        let geneGroup;
 
-        //create a new group for this gene
-        let geneGroup = svg.append('g')
-            // .attr('transform', `translate(${startX - margin.left}, 30)`)
-            .attr('class', 'point-group')
-            .attr('id', `poi-${chr}-${start}-${end}-group`);
+        let isWholeGenome = range[0] == 0 && range[1] == genomeSize;
 
-        geneGroup.append('rect')
-            .attr('x', 0 + margin.left)
-            .attr('class', 'gene-rect')
-            .attr('width', function() {
-                //if the block is too small to see make it 2 pixels wide
-                if (endX - startX < 1) {
-                    return 1;
-                }
-                return endX - startX;
-            })
-            .attr('height', 2)
-            .attr('fill', 'black');
+        if (geneType == 'geneOfInterest') {
+            //Genes of interest
+            geneGroup = svg.append('g')
+                .attr('class', 'point-group-geneofinterest')
+                .attr('id', `poi-${chr}-${start}-${end}-group`);
 
-        if (range[1] - range[0] < chromosomeMap.get('1').end) {
-            //the font needs to be scaled based on the size of the zoomed section inversely proportional to the size of the zoomed section
-            let zoomedSize = range[1] - range[0];
-            // Ensure zoomedSize is at least 1 to avoid taking the logarithm of 0 or a negative number.
-            if (zoomedSize < 1) zoomedSize = 1;
-
-            let bpGenomeSize = originZoom.size;
-            let normalized_window = Math.log(zoomedSize) / Math.log(bpGenomeSize);
-
-            let baseFontSize = 20;
-            let scaledFontSize = baseFontSize * (1 - normalized_window);
+            geneGroup.append('rect')
+                .attr('x', 0 + margin.left)
+                .attr('class', 'gene-rect')
+                .attr('width', function() {
+                    if (endX - startX < 1) {
+                        return 1;
+                    }
+                    return endX - startX;
+                })
+                .attr('height', 2)
+                .attr('fill', 'red');
 
             let measureSvg = d3.create('svg');
             parentElement.appendChild(measureSvg.node());
@@ -659,24 +408,139 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                 .attr('x', 0 + margin.left)
                 .attr('y', 2)
                 .text(gene.gene_symbol)
-                .attr('font-size', `${scaledFontSize}` + "px");
+                .attr('font-size', `${8}` + "px");
             
             let mTextWidth = measureText.node().getBBox().width;
             measureSvg.remove();
 
+            let rect = geneGroup.append('rect')
+                .attr('x', 0 + margin.left)
+                .attr('width', mTextWidth)
+                .attr('height', 8)
+                .attr('fill', 'white')
+                .attr('fill-opacity', 0.85);
+
             //add the labels
             let text = geneGroup.append('text')
+                .attr('class', 'gene-label')
                 .attr('x', 0 + margin.left)
-                .attr('y', 2)
+                .attr('y', 4)
                 .text(gene.gene_symbol)
-                .attr('font-size', `${scaledFontSize}` + "px")
+                .attr('font-size', "8px")
+                .attr('fill', 'red');
+
+            text.attr('transform', `translate(-${mTextWidth}, 0)`);
+            rect.attr('transform', `translate(-${mTextWidth}, -${4})`);
+            return geneGroup;
+        } else if (geneType == 'phenRelatedGene') {
+            //Phen related genes
+            geneGroup = svg.append('g')
+                .attr('class', 'point-group-phenrelated')
+                .attr('id', `poi-${chr}-${start}-${end}-group`);
+
+            geneGroup.append('rect')
+                .attr('x', 0 + margin.left)
+                .attr('class', 'gene-rect')
+                .attr('width', function() {
+                    if (endX - startX < 1) {
+                        return 1;
+                    }
+                    return endX - startX;
+                })
+                .attr('height', 2)
+                .attr('fill', 'blue');
+
+            //we dont show labels for these at the global level
+            if (!isWholeGenome) {
+                let measureSvg = d3.create('svg');
+                parentElement.appendChild(measureSvg.node());
+                
+                let measureText = measureSvg.append('text')
+                    .attr('x', 0 + margin.left)
+                    .attr('y', 2)
+                    .text(gene.gene_symbol)
+                    .attr('font-size', `${8}` + "px");
+                
+                let mTextWidth = measureText.node().getBBox().width;
+                measureSvg.remove();
+
+                let rect = geneGroup.append('rect')
+                    .attr('x', 0 + margin.left)
+                    .attr('width', mTextWidth)
+                    .attr('height', 8)
+                    .attr('fill', 'white')
+                    .attr('fill-opacity', 0.85);
+
+                //add the labels
+                let text = geneGroup.append('text')
+                    .attr('class', 'gene-label')
+                    .attr('x', 0 + margin.left)
+                    .attr('y', 4)
+                    .text(gene.gene_symbol)
+                    .attr('font-size', "8px")
+                    .attr('fill', 'blue');
+
+                text.attr('transform', `translate(-${mTextWidth}, 0)`);
+                rect.attr('transform', `translate(-${mTextWidth}, -${4})`);
+            }
+
+            return geneGroup;
+        } else {
+            //All normal genes
+            geneGroup = svg.append('g')
+                .attr('class', 'point-group')
+                .attr('id', `poi-${chr}-${start}-${end}-group`);
+
+            geneGroup.append('rect')
+                .attr('x', 0 + margin.left)
+                .attr('class', 'gene-rect')
+                .attr('width', function() {
+                    if (endX - startX < 1) {
+                        return 1;
+                    }
+                    return endX - startX;
+                })
+                .attr('height', 2)
                 .attr('fill', 'black');
 
-            text.attr('transform', `translate(-${mTextWidth + 1}, 0)`);
-        }
+            if (isLessThanOneChr) {
+                //the font needs to be scaled based on the size of the zoomed section inversely proportional to the size of the zoomed section
+                let zoomedSize = range[1] - range[0];
+                // Ensure zoomedSize is at least 1 to avoid taking the logarithm of 0 or a negative number.
+                if (zoomedSize < 1) zoomedSize = 1;
 
-        return geneGroup;
+                let bpGenomeSize = originZoom.size;
+                let normalized_window = Math.log(zoomedSize) / Math.log(bpGenomeSize);
+
+                let baseFontSize = 20;
+                let scaledFontSize = baseFontSize * (1 - normalized_window);
+
+                let measureSvg = d3.create('svg');
+                parentElement.appendChild(measureSvg.node());
+                
+                let measureText = measureSvg.append('text')
+                    .attr('x', 0 + margin.left)
+                    .attr('y', 2)
+                    .text(gene.gene_symbol)
+                    .attr('font-size', `${scaledFontSize}` + "px");
+                
+                let mTextWidth = measureText.node().getBBox().width;
+                measureSvg.remove();
+
+                //add the labels
+                let text = geneGroup.append('text')
+                    .attr('class', 'gene-label')
+                    .attr('x', 0 + margin.left)
+                    .attr('y', 2)
+                    .text(gene.gene_symbol)
+                    .attr('font-size', `${scaledFontSize}` + "px")
+                    .attr('fill', 'black');
+
+                text.attr('transform', `translate(-${mTextWidth + 1}, 0)`);
+            }  
+            return geneGroup;
+        }
     }
-    
+
     return svg.node();
 }

--- a/src/d3/linearGeneChart.d3.js
+++ b/src/d3/linearGeneChart.d3.js
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 
 export default function linearGeneChart(parentElement, refChromosomes, data, options=null) {
-    let width = parentElement.clientWidth;
+    let width = parentElement.clientWidth - 10;
     let height = parentElement.clientHeight;
     let chromosomes = refChromosomes;
     let genes = data;
@@ -84,8 +84,6 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
         }
     }
 
-    const margin = {top: 5, right: 10, bottom: 5, left: 10};
-
     const svg = d3.create('svg')
         .attr('viewBox', [0, 0, width, height])
         .attr('class', 'linear-gene-chart-d3')
@@ -123,7 +121,7 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
 
     let x = d3.scaleLinear()
         .domain([zoomedSelection.start, zoomedSelection.end])
-        .range([margin.left, width - margin.right]);
+        .range([0, width]);
 
     _renderGenes([zoomedSelection.start, zoomedSelection.end])
 
@@ -149,10 +147,10 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
     }
 
     function _renderGenes(range) {
-        //grab all the point-group groups and remove them before rendering the new ones
-        svg.selectAll('.point-group').remove();
-        svg.selectAll('.point-group-phenrelated').remove();
-        svg.selectAll('.point-group-geneofinterest').remove();
+        //grab all the gene-group groups and remove them before rendering the new ones
+        svg.selectAll('.gene-group').remove();
+        svg.selectAll('.gene-group-phenrelated').remove();
+        svg.selectAll('.gene-group-geneofinterest').remove();
 
         let isWholeGenome = range[0] == 0 && range[1] == genomeSize;
         let isLessThanOneChr = range[1] - range[0] <= chromosomeMap.get('1').end;
@@ -257,11 +255,11 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                         break;
                     }
 
-                    if ((startX - mTextWidth) > tracMap[x]) {
+                    if ((startX - mTextWidth) > tracMap[x] + 2) {
                         tracMap[x] = endX;
                         currentTrac = x;
                         break;
-                    } else if ((startX - mTextWidth) < tracMap[x]) {
+                    } else if ((startX - mTextWidth) < tracMap[x] + 2) {
                         continue;
                     }
                 }
@@ -274,7 +272,7 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                         .attr('height', height);
                 }
 
-                geneGroup.attr('transform', `translate(${startX - margin.left}, ${translateY + 25})`);
+                geneGroup.attr('transform', `translate(${startX + 30}, ${translateY + 25})`);
 
                 svg.append(() => geneGroup.node()); //append the gene group to the svg
             } else {
@@ -389,29 +387,36 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
         if (geneType == 'geneOfInterest') {
             //Genes of interest
             geneGroup = svg.append('g')
-                .attr('class', 'point-group-geneofinterest')
+                .attr('class', 'gene-group-geneofinterest')
+                .data([gene])
                 .attr('id', `poi-${chr}-${start}-${end}-group`);
 
             geneGroup.append('rect')
-                .attr('x', 0 + margin.left)
+                .attr('x', 0)
                 .attr('class', 'gene-rect')
                 .attr('width', function() {
                     if (endX - startX < 1) {
-                        return 1;
+                        return 2;
                     }
                     return endX - startX;
                 })
-                .attr('height', 2)
-                .attr('fill', 'red');
+                .attr('height', 4)
+                .attr('fill', 'red')
+                .attr('rx', function() {
+                    if (endX - startX < 1) {
+                        return 0;
+                    }
+                    return 1; 
+                });
 
             let measureSvg = d3.create('svg');
             parentElement.appendChild(measureSvg.node());
             
             let measureText = measureSvg.append('text')
-                .attr('x', 0 + margin.left)
-                .attr('y', 2)
+                .attr('x', 0)
+                .attr('y', 5)
                 .text(gene.gene_symbol)
-                .attr('font-size', `${8}` + "px");
+                .attr('font-size', `${10}` + "px");
             
             let mTextWidth = measureText.node().getBBox().width;
             measureSvg.remove();
@@ -419,10 +424,10 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
             //add the labels
             let text = geneGroup.append('text')
                 .attr('class', 'gene-label')
-                .attr('x', 0 + margin.left)
-                .attr('y', 4)
+                .attr('x', 0)
+                .attr('y', 5)
                 .text(gene.gene_symbol)
-                .attr('font-size', "8px")
+                .attr('font-size', "10px")
                 .attr('fill', 'red');
 
             text.attr('transform', `translate(-${mTextWidth}, 0)`);
@@ -431,20 +436,27 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
         } else if (geneType == 'phenRelatedGene') {
             //Phen related genes
             geneGroup = svg.append('g')
-                .attr('class', 'point-group-phenrelated')
+                .attr('class', 'gene-group-phenrelated')
+                .data([gene])
                 .attr('id', `poi-${chr}-${start}-${end}-group`);
 
             geneGroup.append('rect')
-                .attr('x', 0 + margin.left)
+                .attr('x', 0)
                 .attr('class', 'gene-rect')
                 .attr('width', function() {
                     if (endX - startX < 1) {
-                        return 1;
+                        return 2;
                     }
                     return endX - startX;
                 })
-                .attr('height', 2)
-                .attr('fill', 'blue');
+                .attr('height', 4)
+                .attr('fill', 'blue')
+                attr('rx', function() {
+                    if (endX - startX < 1) {
+                        return 0;
+                    }
+                    return 1; 
+                });
 
             //we dont show labels for these at the global level
             if (!isWholeGenome) {
@@ -452,10 +464,10 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                 parentElement.appendChild(measureSvg.node());
                 
                 let measureText = measureSvg.append('text')
-                    .attr('x', 0 + margin.left)
-                    .attr('y', 2)
+                    .attr('x', 0)
+                    .attr('y', 5)
                     .text(gene.gene_symbol)
-                    .attr('font-size', `${8}` + "px");
+                    .attr('font-size', `${10}` + "px");
                 
                 let mTextWidth = measureText.node().getBBox().width;
                 measureSvg.remove();
@@ -463,11 +475,12 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                 //add the labels
                 let text = geneGroup.append('text')
                     .attr('class', 'gene-label')
-                    .attr('x', 0 + margin.left)
-                    .attr('y', 4)
+                    .attr('x', 0)
+                    .attr('y', 5)
                     .text(gene.gene_symbol)
-                    .attr('font-size', "8px")
-                    .attr('fill', 'blue');
+                    .attr('font-size', "10px")
+                    .attr('fill', 'blue')
+                    .attr('rx', 1);
 
                 text.attr('transform', `translate(-${mTextWidth}, 0)`);
             }
@@ -476,20 +489,30 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
         } else {
             //All normal genes
             geneGroup = svg.append('g')
-                .attr('class', 'point-group')
-                .attr('id', `poi-${chr}-${start}-${end}-group`);
+                .attr('class', 'gene-group')
+                .data([gene])
+                .attr('id', `poi-${chr}-${start}-${end}-group`)
+                .on('click', function(event, d) {
+                    console.log('clicked on gene', d);
+                });
 
             geneGroup.append('rect')
-                .attr('x', 0 + margin.left)
+                .attr('x', 0)
                 .attr('class', 'gene-rect')
                 .attr('width', function() {
                     if (endX - startX < 1) {
-                        return 1;
+                        return 2;
                     }
                     return endX - startX;
                 })
-                .attr('height', 2)
-                .attr('fill', 'black');
+                .attr('height', 4)
+                .attr('fill', 'black')
+                .attr('rx', function() {
+                    if (endX - startX < 1) {
+                        return 0;
+                    }
+                    return 1; 
+                });
 
             if (isLessThanOneChr) {
                 //the font needs to be scaled based on the size of the zoomed section inversely proportional to the size of the zoomed section
@@ -502,13 +525,15 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
 
                 let baseFontSize = 20;
                 let scaledFontSize = baseFontSize * (1 - normalized_window);
+                let minFontSize = 8;
+                scaledFontSize = Math.max(scaledFontSize, minFontSize);
 
                 let measureSvg = d3.create('svg');
                 parentElement.appendChild(measureSvg.node());
                 
                 let measureText = measureSvg.append('text')
-                    .attr('x', 0 + margin.left)
-                    .attr('y', 2)
+                    .attr('x', 0)
+                    .attr('y', 4)
                     .text(gene.gene_symbol)
                     .attr('font-size', `${scaledFontSize}` + "px");
                 
@@ -518,8 +543,8 @@ export default function linearGeneChart(parentElement, refChromosomes, data, opt
                 //add the labels
                 let text = geneGroup.append('text')
                     .attr('class', 'gene-label')
-                    .attr('x', 0 + margin.left)
-                    .attr('y', 2)
+                    .attr('x', 0)
+                    .attr('y', 4)
                     .text(gene.gene_symbol)
                     .attr('font-size', `${scaledFontSize}` + "px")
                     .attr('fill', 'black');


### PR DESCRIPTION
- Refactor the gene chart code
- Allow genes to stack indefinitely as needed
- Take into account the gene label in the stacking context so that labels don't overlap
- #80 Restrict the focus on variant to that variant's chromosome (so we don't cross boundaries on that)
- Improve the labels on the idiogram-scale-bar for scale and location
- Fix misalignment on idiogram-scale-bar to other linear charts