### PR TITLE
Refactor file select

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -96,7 +96,6 @@
         :genesOfInterest="genesOfInterest"
         :phenRelatedGenes="overlappedPhenGenes"
         :batchNum="batchNum"
-        :multiSampleVcf="multiSampleVcf"
         :focusedGeneName="focusedGeneName"
         :genomeEnd="genomeEnd"
         :genomeStart="genomeStart"
@@ -164,6 +163,7 @@
         samples: {
           proband: {
             name: 'Proband',
+            id: null,
             vcf: '',
             tbi: '',
             bam: '',
@@ -173,7 +173,6 @@
           comparisons: []
         },
         toasts: [],
-        multiSampleVcf: false,
         variantsSorted: false,
         qualityStats: {},
         variantsFilteredOut: [],
@@ -236,7 +235,7 @@
         let newGenes = this.genesOfInterest.filter(g => g !== gene);
         this.updateGenesOfInterest(newGenes);
       },
-      async loadData(isMultiple=false) {
+      async loadData() {
         if (this.samples.proband.vcf == '') {
           //open the select data section too
           this.selectDataSectionOpen = true;
@@ -250,7 +249,7 @@
         let svList; 
         
         try {
-          if (!isMultiple) {
+          if (!this.samples.proband.id || this.samples.proband.id == '') {
             svList = await dataHelper.getSVsFromVCF(url);
           } else {
             svList = await dataHelper.getSVsFromVCF(url, this.samples.proband.id)
@@ -395,8 +394,7 @@
          */
         return Object.values(overlappedGenes).some(gene => Object.keys(gene.phenotypes) && Object.keys(gene.phenotypes).length > 0);
       },
-      async updateSamples(samples, isMultiple=false) {
-        this.multiSampleVcf = isMultiple;
+      async updateSamples(samples) {
         //if samples @ 0 is the same as the old samples @ 0 then we dont need to load data again but 
         //if the vcf is different we do
         if (samples.proband.vcf == this.samples.proband.vcf) {
@@ -405,11 +403,11 @@
           return;
         } else {
           this.samples.proband = samples.proband;
-          this.loadData(this.multiSampleVcf);
+          this.loadData();
         }
         this.samples.comparisons = samples.comparisons;
         
-        if (!isMultiple) {
+        if (!samples.proband.id || samples.proband.id == '') {
           this.qualityStats.proband = await dataHelper.getQualityFromVCF(samples.proband.vcf);
         } else {
           this.qualityStats.proband = await dataHelper.getQualityFromVCF(samples.proband.vcf, samples.proband.id);
@@ -671,7 +669,7 @@
       samples: {
         handler(newVal, oldVal) {
           if (newVal.proband.vcf !== oldVal.proband.vcf) {
-            this.loadData(this.multiSampleVcf);
+            this.loadData();
           }
         },
         deep: true

--- a/src/components/LeftTracksSection.vue
+++ b/src/components/LeftTracksSection.vue
@@ -153,7 +153,6 @@
     focusedGeneName: String,
     batchNum: Number,
     samples: Object,
-    multiSampleVcf: Boolean,
     genomeStart: Number,
     genomeEnd: Number
   },
@@ -259,7 +258,7 @@
           let data;
           let svData;
           
-          if (!this.multiSampleVcf && !sample.id) {
+          if (!sample.id || sample.id === '') {
             data = await dataHelper.getSVsFromVCF(sample.vcf);
             svData = data.map(item => new Sv(item));
           } else {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -139,7 +139,7 @@
       width: 100%
       background-color: #0D60C3
       color: white
-      z-index: 4
+      z-index: 5
       .column-container
         display: flex
         flex-direction: column

--- a/src/components/SelectDataSection.vue
+++ b/src/components/SelectDataSection.vue
@@ -1,12 +1,6 @@
 <template>
     <div class="select-data-section" :class="{hidden: !show}">
-        <fieldset>
-            <legend>VCF Input Format</legend>
-            <input type="radio" id="joint" name="vcfs-format" value="joint" v-model="samplesFormat">
-            <label for="multiple">Joint-Called VCF</label>
-            <input type="radio" id="individual" name="vcfs-format" value="individual" v-model="samplesFormat">
-            <label for="individual">Seperate VCFs</label>
-        </fieldset>
+        <h1>FILES</h1>
 
         <div id="individual-samples-container" v-if="samplesFormat == 'individual'">
             <SampleDataRow 
@@ -26,60 +20,7 @@
                 @update-sample="(sample) => updateSample(index, sample)"
                 @update-sample-files="addFileToWaygate"/>            
         </div>
-
-        <div id="joint-samples-container" v-if="samplesFormat == 'joint'">
-            <div class="label-input-wrapper">
-                <label for="vcf">VCF:</label>
-                <input type="text" id="vcf" placeholder="Paste a link or select a local file..." v-model="jointVcfUrl"/>
-                <button @click="openFileSelect">Choose Local</button>
-                <button @click="getSampleNames" id="fetch-samples-btn">Fetch Samples</button>
-            </div>
-
-            <div id="samples-section" v-if="jointVcfHeaders.length > 0">
-                <fieldset>
-                    <legend>Proband Sample</legend>
-                    <div class="label-input-wrapper">
-                        <label for="proband">Proband Sample Id</label>
-                        <select id="proband" v-model="samplesLocal.proband.id">
-                            <option v-for="header in jointVcfHeaders" :key="header">{{header}}</option>
-                        </select>
-                    </div>
-                    <div class="label-input-wrapper">
-                        <label for="proband-name">Sample Name</label>
-                        <input type="text" id="proband-name" v-model="samplesLocal.proband.name"/>
-                    </div>
-                </fieldset>
-
-                <div class="label-input-wrapper" v-if="jointVcfHeaders.filter(id => id !== samplesLocal.proband.id).length > 0">
-                    <label for="comparison-samples">Select Comparison Samples</label>
-                    <select name="comparison-samples" id="comparisons" multiple v-model="selectedComparisonSamples">
-                        <option v-for="header in jointVcfHeaders.filter(id => id !== samplesLocal.proband.id)" :key="header">{{header}}</option>
-                    </select>
-                </div>
-                <div v-else><strong>Only one sample detected in:</strong> {{ jointVcfUrl }}</div>
-
-                <div class="sample-fieldset-wrapper" v-for="(sample, index) in selectedComparisonSamples" :key="index">
-                    <fieldset>
-                        <legend>ID: {{sample}}</legend>
-                        <div class="label-input-wrapper">
-                            <label for="comparison-name">Sample Name</label>
-                            <input type="text" id="comparison-name" v-model="samplesLocal.comparisons[index].name"/>
-                        </div>
-                    </fieldset>
-                </div>
-
-                <SampleDataRow 
-                    v-for="(sample, index) in samplesLocal.comparisons.filter(sample => !jointVcfHeaders.includes(sample.id))" 
-                    :key="index" 
-                    :sample="sample"
-                    @close-row="removeRow(index)"
-                    @open-waygate="startWaygate"
-                    @update-sample-files="addFileToWaygate"/>
-            </div>
-        </div>
-
         <button class="add-btn" @click="addNewSample" v-if="samplesFormat == 'individual'">+</button>
-        <button class="add-additional-btn" @click="addNewSample" v-if="samplesFormat == 'joint' && (jointVcfHeaders && samplesLocal.proband.id)">Add Additional VCF</button>
         <button class="go-btn" @click="sendSamples" v-if="samplesFormat == 'individual' || (jointVcfHeaders && samplesLocal.proband.id)">GO</button>
     </div>
 </template>

--- a/src/components/SelectDataSection.vue
+++ b/src/components/SelectDataSection.vue
@@ -14,6 +14,7 @@
                 :sample="samplesLocal.proband" 
                 :isProband="true"
                 @open-waygate="startWaygate"
+                @update-sample="(sample) => updateSample('proband', sample)"
                 @update-sample-files="addFileToWaygate"/>
 
             <SampleDataRow 
@@ -22,6 +23,7 @@
                 :sample="sample"
                 @close-row="removeRow(index)"
                 @open-waygate="startWaygate"
+                @update-sample="(sample) => updateSample(index, sample)"
                 @update-sample-files="addFileToWaygate"/>            
         </div>
 
@@ -114,6 +116,13 @@ export default {
         this.samplesLocal = JSON.parse(JSON.stringify(this.samples))
     },
     methods: {
+        updateSample(loc, sample) {
+            if (loc === 'proband') {
+                this.samplesLocal.proband = sample
+            } else {
+                this.samplesLocal.comparisons[loc] = sample
+            }
+        },
         addNewSample() {
             this.samplesLocal.comparisons.push({
                 name: '',

--- a/src/components/SelectDataSection.vue
+++ b/src/components/SelectDataSection.vue
@@ -9,6 +9,7 @@
                 :isProband="true"
                 @open-waygate="startWaygate"
                 @update-sample="(sample) => updateSample('proband', sample)"
+                @add-other-samples="addMultipleSamples"
                 @update-sample-files="addFileToWaygate"/>
 
             <SampleDataRow 
@@ -18,6 +19,7 @@
                 @close-row="removeRow(index)"
                 @open-waygate="startWaygate"
                 @update-sample="(sample) => updateSample(index, sample)"
+                @add-other-samples="addMultipleSamples"
                 @update-sample-files="addFileToWaygate"/>            
         </div>
         <button class="add-btn" @click="addNewSample" v-if="samplesFormat == 'individual'">+</button>
@@ -74,6 +76,20 @@ export default {
                 bai: '',
                 svList: [],
             })
+        },
+        addMultipleSamples(samples) {
+            for (let sample of samples) {
+                this.samplesLocal.comparisons.push({
+                    name: 'New Sample',
+                    id: sample.id,
+                    vcf: sample.vcf,
+                    tbi: '',
+                    bam: '',
+                    bai: '',
+                    svList: [],
+                })
+
+            }
         },
         sendSamples () {
             this.$emit('update-samples', JSON.parse(JSON.stringify(this.samplesLocal)))

--- a/src/components/SelectDataSection.vue
+++ b/src/components/SelectDataSection.vue
@@ -66,8 +66,8 @@ export default {
         },
         addNewSample() {
             this.samplesLocal.comparisons.push({
-                name: '',
-                id: '',
+                name: 'New Sample',
+                id: null,
                 vcf: '',
                 tbi: '',
                 bam: '',
@@ -76,11 +76,7 @@ export default {
             })
         },
         sendSamples () {
-            if (this.samplesFormat === 'individual') {
-                this.$emit('update-samples', JSON.parse(JSON.stringify(this.samplesLocal)), false)
-            } else {
-                this.$emit('update-samples', JSON.parse(JSON.stringify(this.samplesLocal)), true)
-            }
+            this.$emit('update-samples', JSON.parse(JSON.stringify(this.samplesLocal)))
             this.$emit('toggle-show')
         },
         removeRow (index) {
@@ -248,7 +244,7 @@ export default {
         transition: height 0.5s ease-in-out, width 0.5s ease-in-out
         box-shadow: 0px 0px 5px 0px #2A65B7
         box-sizing: border-box
-        z-index: 3
+        z-index: 4
         overflow-y: auto
         &.hidden
             height: 0px

--- a/src/components/SelectDataSection.vue
+++ b/src/components/SelectDataSection.vue
@@ -246,6 +246,9 @@ export default {
         box-sizing: border-box
         z-index: 4
         overflow-y: auto
+        h1
+            color: #2A65B7
+            font-weight: normal
         &.hidden
             height: 0px
             width: 0px

--- a/src/components/parts/SampleDataRow.vue
+++ b/src/components/parts/SampleDataRow.vue
@@ -10,7 +10,7 @@
                 <label for="file-format">File Format:</label>
                 <select name="file-format" id="format" v-model="fileFormat">
                     <option value="single">single sample</option>
-                    <option value="joint">joint call</option>
+                    <option value="joint">joint called</option>
                 </select>
                 
                 <label for="vcf">VCF:</label>
@@ -23,12 +23,12 @@
                 <label for="sample-id">Sample Name:</label>
                 <input type="text" id="sample-id" v-model="sampleLocal.name"/>
 
-                <div v-if="sampleOptions">
+                <div v-if="sampleOptions && fileFormat == 'joint'">
                     <label for="sample-id">Sample Id:</label>
                     <select name="sample-id" id="sample-id" v-model="sampleLocal.id">
                         <option v-for="option in sampleOptions" :value="option">{{ option }}</option>
                     </select>
-                    <button></button>
+                    <button>Create All Samples</button>
                 </div>
             </div>
 
@@ -65,7 +65,7 @@ export default {
     data () {
         return {
             collapse: false,
-            fileFormat: 'single',
+            fileFormat: 'joint',
             sampleOptions: null,
             sampleLocal: JSON.parse(JSON.stringify(this.sample))
         }
@@ -131,7 +131,6 @@ export default {
         sampleLocal: {
             handler: function (val, oldVal) {
                 if (val !== oldVal) {
-                    console.log('emitting update-sample')
                     this.$emit('update-sample', val)
                 }
             },
@@ -150,13 +149,14 @@ export default {
         position: relative
         display: flex
         border-radius: 5px
-        margin: 5px 0px
+        margin: 10px 0px
         justify-content: space-between
         align-items: center
-        padding: 5px 10px
+        padding: 10px 10px
         box-sizing: border-box
         border: 1px solid #2A65B7
         transition: height 0.5s ease-in-out
+        background-color: white
         &.collapse
             height: 50px
         .collapse-row-btn
@@ -199,10 +199,11 @@ export default {
                     margin-left: 10px
                 input
                     padding: 5px
-                    border: 1px solid #2A65B7
+                    border: none
                     border-radius: 5px
                     box-sizing: border-box
                     flex-grow: 1
+                    background-color: #F2F5FD
                     //standard-modern
                     &::placeholder
                         font-style: italic
@@ -217,9 +218,10 @@ export default {
                         font-style: italic
                 select
                     padding: 5px
-                    border: 1px solid #2A65B7
+                    border: none
                     border-radius: 5px
                     box-sizing: border-box
+                    background-color: #F2F5FD
                     //standard-modern
                     &::placeholder
                         font-style: italic

--- a/src/components/parts/SampleDataRow.vue
+++ b/src/components/parts/SampleDataRow.vue
@@ -7,16 +7,16 @@
         </button>
         <div class="sample-row-info-form" v-if="!collapse">
             <div class="label-input-wrapper link">
-                <label for="file-format">File Format:</label>
-                <select name="file-format" id="format" v-model="fileFormat">
-                    <option value="single">single sample</option>
-                    <option value="joint">joint called</option>
+                <label for="file-format">Format:</label>
+                <select class="type" name="file-format" id="format" v-model="fileFormat">
+                    <option value="single">Single Sample</option>
+                    <option value="joint">Joint Called</option>
                 </select>
                 
                 <label for="vcf">VCF:</label>
                 <input type="text" class="vcf" v-model="sampleLocal.vcf" placeholder="Paste a link or select a local file..."/>
-                <button @click="openFileSelect($event)">Choose Local</button>
-                <button v-if="fileFormat == 'joint'" @click="getSampleNames">Fetch Samples</button>
+                <button @click="openFileSelect($event)">Select Local</button>
+                <button v-if="fileFormat == 'joint'" @click="getSampleNames">Get Samples</button>
             </div>
 
             <div class="label-input-wrapper">
@@ -28,7 +28,7 @@
                     <select name="sample-id" id="sample-id" v-model="sampleLocal.id">
                         <option v-for="option in sampleOptions" :value="option">{{ option }}</option>
                     </select>
-                    <button>Add Other Samples
+                    <button class="special-btn">Add Other Samples
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                             <title>add remaining samples</title>
                             <path d="M19 17V19H7V17S7 13 13 13 19 17 19 17M16 8A3 3 0 1 0 13 11A3 3 0 0 0 16 8M19.2 13.06A5.6 5.6 0 0 1 21 17V19H24V17S24 13.55 19.2 13.06M18 5A2.91 2.91 0 0 0 17.11 5.14A5 5 0 0 1 17.11 10.86A2.91 2.91 0 0 0 18 11A3 3 0 0 0 18 5M8 10H5V7H3V10H0V12H3V15H5V12H8Z" />
@@ -205,10 +205,11 @@ export default {
                 input
                     padding: 5px
                     border: none
-                    border-radius: 5px
+                    border-radius: 5px 5px 0px 0px
+                    border-bottom: 1px solid transparent
                     box-sizing: border-box
                     flex-grow: 1
-                    background-color: #F2F5FD
+                    background-color: #F8F8F8
                     //standard-modern
                     &::placeholder
                         font-style: italic
@@ -221,12 +222,15 @@ export default {
                     // edge
                     &:-ms-input-placeholder
                         font-style: italic
+                    &:focus
+                        outline: none
+                        border-bottom: 1px solid #1A4B97
                 select
                     padding: 5px
                     border: none
                     border-radius: 5px
                     box-sizing: border-box
-                    background-color: #F2F5FD
+                    background-color: #EBEBEB
                     //standard-modern
                     &::placeholder
                         font-style: italic
@@ -239,9 +243,12 @@ export default {
                     // edge
                     &:-ms-input-placeholder
                         font-style: italic
+                    &.type
+                        font-weight: bold
+                        text-align: center
                 button
-                    background-color: #2A65B7
-                    color: white
+                    background-color: #EBEBEB
+                    color: #474747
                     border: none
                     display: flex
                     justify-content: center
@@ -250,13 +257,24 @@ export default {
                     padding: 5px 10px
                     cursor: pointer
                     margin-left: 10px
+                    text-transform: uppercase
                     &:hover
-                        background-color: #1A4B97
+                        background-color: #D9D9D9
                     svg
                         height: 20px
                         width: 20px
                         margin-left: 5px
                         fill: white
+                .special-btn
+                    background-color: #8BB0E5
+                    color: black
+                    border: 1px solid #2A65B7
+                    text-transform: none
+                    font-weight: 600
+                    svg
+                        fill: black
+                    &:hover
+                        background-color: #6B90D5
         .collapsed-alt-text
             width: 100%
             text-align: center

--- a/src/components/parts/SampleDataRow.vue
+++ b/src/components/parts/SampleDataRow.vue
@@ -6,15 +6,32 @@
             <img v-else src="/arrow-up-circle.svg" alt="close">
         </button>
         <div class="sample-row-info-form" v-if="!collapse">
+            <div class="label-input-wrapper link">
+                <label for="file-format">File Format:</label>
+                <select name="file-format" id="format" v-model="fileFormat">
+                    <option value="single">single sample</option>
+                    <option value="joint">joint call</option>
+                </select>
+                
+                <label for="vcf">VCF:</label>
+                <input type="text" class="vcf-link" v-model="sample.vcf" placeholder="Paste a link or select a local file..."/>
+                <button @click="openFileSelect($event)">Choose Local</button>
+                <button v-if="fileFormat == 'joint'">Fetch Samples</button>
+
+                <select v-if="sampleOptions" name="samples" id="">
+                    <option v-for="option in sampleOptions" :value="option">{{ option }}</option>
+                </select>
+            </div>
+
             <div class="label-input-wrapper">
                 <label for="sample-id">Sample Name:</label>
                 <input type="text" id="sample-id" v-model="sample.name"/>
+
+                <div v-if="sampleOptions">
+                    <button>create</button>
+                </div>
             </div>
-            <div class="label-input-wrapper link">
-                <label for="vcf">VCF:</label>
-                <input type="text" id="vcf" v-model="sample.vcf" placeholder="Paste a link or select a local file..."/>
-                <button @click="openFileSelect($event)">Choose Local</button>
-            </div>
+
             <!-- <div class="label-input-wrapper link">
                 <label for="bam">BAM (opt.): </label>
                 <input type="text" id="bam" v-model="sample.bam" placeholder="Paste a link or select a local file..."/>
@@ -47,6 +64,8 @@ export default {
     data () {
         return {
             collapse: false,
+            fileFormat: 'single',
+            sampleOptions: null,
         }
     },
     mounted () {
@@ -146,16 +165,33 @@ export default {
                 align-items: center
                 margin: 5px 0px
                 label
-                    width: 20%
-                    min-width: 100px
+                    width: fit-content
                     text-align: right
                     margin-right: 10px
+                    margin-left: 10px
                 input
                     padding: 5px
                     border: 1px solid #2A65B7
                     border-radius: 5px
                     box-sizing: border-box
                     flex-grow: 1
+                    //standard-modern
+                    &::placeholder
+                        font-style: italic
+                    // firefox
+                    &:-moz-placeholder
+                        font-style: italic
+                    // safari
+                    &::-webkit-input-placeholder
+                        font-style: italic
+                    // edge
+                    &:-ms-input-placeholder
+                        font-style: italic
+                select
+                    padding: 5px
+                    border: 1px solid #2A65B7
+                    border-radius: 5px
+                    box-sizing: border-box
                     //standard-modern
                     &::placeholder
                         font-style: italic

--- a/src/components/parts/SampleDataRow.vue
+++ b/src/components/parts/SampleDataRow.vue
@@ -23,12 +23,14 @@
                 <label for="sample-id">Sample Name:</label>
                 <input type="text" id="sample-id" v-model="sampleLocal.name"/>
 
-                <div class="row" v-if="sampleOptions && fileFormat == 'joint'">
+                <div class="row" v-if="(sampleOptions && fileFormat == 'joint') || sampleLocal.id">
                     <label for="sample-id">Sample Id:</label>
                     <select name="sample-id" id="sample-id" v-model="sampleLocal.id">
                         <option v-for="option in sampleOptions" :value="option">{{ option }}</option>
+                        <option v-if="!sampleOptions" :value="sampleLocal.id">{{ sampleLocal.id }}</option>
                     </select>
-                    <button class="special-btn">Add Other Samples
+
+                    <button v-if="sampleOptions && sampleOptions.length > 1" @click="sendAdditionalSamples" class="special-btn">Add Other Samples
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                             <title>add remaining samples</title>
                             <path d="M19 17V19H7V17S7 13 13 13 19 17 19 17M16 8A3 3 0 1 0 13 11A3 3 0 0 0 16 8M19.2 13.06A5.6 5.6 0 0 1 21 17V19H24V17S24 13.55 19.2 13.06M18 5A2.91 2.91 0 0 0 17.11 5.14A5 5 0 0 1 17.11 10.86A2.91 2.91 0 0 0 18 11A3 3 0 0 0 18 5M8 10H5V7H3V10H0V12H3V15H5V12H8Z" />
@@ -119,6 +121,24 @@ export default {
                     type: 'error'
                 })
             }
+        },
+        sendAdditionalSamples() {
+            if (!this.sampleOptions) {
+                return
+            }
+
+            let otherSamples = this.sampleOptions.filter(sample => sample !== this.sampleLocal.id);
+            let samples = [];
+
+            for (let sample of otherSamples) {
+                let url = this.sampleLocal.vcf;
+                let s = {
+                    id: sample,
+                    vcf: url
+                }
+                samples.push(s)
+            }
+            this.$emit('add-other-samples', samples)
         }
     },
     watch: {

--- a/src/components/parts/SampleDataRow.vue
+++ b/src/components/parts/SampleDataRow.vue
@@ -14,18 +14,18 @@
                 </select>
                 
                 <label for="vcf">VCF:</label>
-                <input type="text" class="vcf" v-model="sampleLocal.vcf" placeholder="Paste a link or select a local file..."/>
+                <input type="text" class="vcf" @input="this.$emit('update-sample', this.sampleLocal)" v-model="sampleLocal.vcf" placeholder="Paste a link or select a local file..."/>
                 <button @click="openFileSelect($event)">Select Local</button>
                 <button v-if="fileFormat == 'joint'" @click="getSampleNames">Get Samples</button>
             </div>
 
             <div class="label-input-wrapper">
                 <label for="sample-id">Sample Name:</label>
-                <input type="text" id="sample-id" v-model="sampleLocal.name"/>
+                <input type="text" id="sample-id" v-model="sampleLocal.name" @input="this.$emit('update-sample', this.sampleLocal)"/>
 
                 <div class="row" v-if="(sampleOptions && fileFormat == 'joint') || sampleLocal.id">
                     <label for="sample-id">Sample Id:</label>
-                    <select name="sample-id" id="sample-id" v-model="sampleLocal.id">
+                    <select name="sample-id" id="sample-id" @change="this.$emit('update-sample', this.sampleLocal)" v-model="sampleLocal.id">
                         <option v-for="option in sampleOptions" :value="option">{{ option }}</option>
                         <option v-if="!sampleOptions" :value="sampleLocal.id">{{ sampleLocal.id }}</option>
                     </select>
@@ -153,13 +153,12 @@ export default {
             },
             deep: true
         },
-        sampleLocal: {
+        sampleOptions: {
             handler: function (val, oldVal) {
-                if (val !== oldVal) {
-                    this.$emit('update-sample', val)
+                if (!oldVal || oldVal.length === 0) {
+                    this.sampleLocal.id = val[0]
                 }
-            },
-            deep: true
+            }
         }
     },
     computed: {

--- a/src/components/parts/SampleDataRow.vue
+++ b/src/components/parts/SampleDataRow.vue
@@ -23,12 +23,17 @@
                 <label for="sample-id">Sample Name:</label>
                 <input type="text" id="sample-id" v-model="sampleLocal.name"/>
 
-                <div v-if="sampleOptions && fileFormat == 'joint'">
+                <div class="row" v-if="sampleOptions && fileFormat == 'joint'">
                     <label for="sample-id">Sample Id:</label>
                     <select name="sample-id" id="sample-id" v-model="sampleLocal.id">
                         <option v-for="option in sampleOptions" :value="option">{{ option }}</option>
                     </select>
-                    <button>Create All Samples</button>
+                    <button>Add Other Samples
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                            <title>add remaining samples</title>
+                            <path d="M19 17V19H7V17S7 13 13 13 19 17 19 17M16 8A3 3 0 1 0 13 11A3 3 0 0 0 16 8M19.2 13.06A5.6 5.6 0 0 1 21 17V19H24V17S24 13.55 19.2 13.06M18 5A2.91 2.91 0 0 0 17.11 5.14A5 5 0 0 1 17.11 10.86A2.91 2.91 0 0 0 18 11A3 3 0 0 0 18 5M8 10H5V7H3V10H0V12H3V15H5V12H8Z" />
+                        </svg>
+                    </button>
                 </div>
             </div>
 
@@ -238,12 +243,20 @@ export default {
                     background-color: #2A65B7
                     color: white
                     border: none
+                    display: flex
+                    justify-content: center
+                    align-items: center
                     border-radius: 5px
                     padding: 5px 10px
                     cursor: pointer
                     margin-left: 10px
                     &:hover
                         background-color: #1A4B97
+                    svg
+                        height: 20px
+                        width: 20px
+                        margin-left: 5px
+                        fill: white
         .collapsed-alt-text
             width: 100%
             text-align: center
@@ -269,4 +282,17 @@ export default {
                 &:hover
                     background-color: #F0F0F0
                     box-shadow: 0px 0px 5px 0px #2A65B7
+
+        .row
+            display: flex
+            justify-content: flex-start
+            align-items: center
+            .label-input-wrapper
+                margin: 0px
+                label
+                    margin: 0px
+                select
+                    margin: 0px
+                button
+                    margin: 0px
 </style>


### PR DESCRIPTION

This pull request includes several changes to the `src/App.vue` and related components to simplify the handling of VCF files and improve the user interface. The main changes include the removal of the `multiSampleVcf` property, updates to the sample data handling, and UI enhancements.

### Simplification of VCF Handling:
* Removed the `multiSampleVcf` property and related logic from `src/App.vue` and `src/components/LeftTracksSection.vue`. 
* Updated the `loadData` and `updateSamples` methods to use the `proband.id` property instead of the `multiSampleVcf` flag.

### Sample Data Handling:
* Added `id` property to the `proband` sample and updated the logic to handle multiple samples more efficiently in `src/App.vue`.
* Introduced new methods in `SelectDataSection.vue` to update and add multiple samples, replacing the previous joint and individual VCF handling. 
### UI Enhancements:
* Improved the `SampleDataRow.vue` component to allow selecting the sample format and fetching sample names for joint-called VCFs. 
* Updated the styling and layout in `SampleDataRow.vue` to enhance the user interface. 

### Minor UI Fixes:
* Adjusted the `z-index` property in `NavBar.vue` and `SelectDataSection.vue` for better layering of UI elements.