### PR TITLE
Allow show/hide more for the genes in the sv details

### DIFF
--- a/src/components/LowerModal.vue
+++ b/src/components/LowerModal.vue
@@ -36,7 +36,7 @@
                                 Fetching Overlapping SVs in Population <span class="blinking-elipse"></span>
                             </div>
                             <div class="none-found-message" v-else-if="popSvs && popSvs.length == 0">
-                                No Overlapping SVs Found In Population (@80% Overlap)
+                                No Overlapping SVs Found In Population (80% overlap threshold)
                             </div>
                             <div v-else class="pop-sv" v-for="sv in popSvs">
                                 <div>Overlap: {{ sv.overlapFractionProd.toFixed(3) }}</div>

--- a/src/components/LowerModal.vue
+++ b/src/components/LowerModal.vue
@@ -82,9 +82,14 @@
                     <div
                         class="row show-more-genes"
                         v-if="
-                            type == 'variant' && variant && Object.values(variant.overlappedGenes).length > 0 && hideExtraGeneInfo
+                            type == 'variant' &&
+                            variant &&
+                            Object.values(variant.overlappedGenes).length > 0 &&
+                            sortedIrrelevantGenes.length > 0
                         ">
-                        <div class="show-btn" @click="hideExtraGeneInfo = !hideExtraGeneInfo">Show Additional Genes</div>
+                        <div class="show-btn" @click="hideExtraGeneInfo = !hideExtraGeneInfo">
+                            <span v-if="hideExtraGeneInfo">Show Additional Genes</span><span v-else>Hide Additional Genes</span>
+                        </div>
                     </div>
 
                     <div

--- a/src/components/LowerModal.vue
+++ b/src/components/LowerModal.vue
@@ -27,9 +27,7 @@
                             <div class="item">
                                 <span v-html="bpFormatted(variant.size)"></span>
                             </div>
-                            <div class="item">
-                                {{ formatGenotype(variant.genotype, true) }} ({{ variant.genotype.slice(0, 3) }})
-                            </div>
+                            <div class="item" v-html="svgForZygosity(variant.genotype)"></div>
                             <div class="item">{{ formatType(variant.type) }}</div>
                         </div>
 
@@ -108,6 +106,7 @@ export default {
     },
     methods: {
         formatGenotype: common.formatGenotype,
+        svgForZygosity: common.svgForZygosity,
         bpFormatted: common.bpFormatted,
         formatType: common.formatType,
         close() {
@@ -321,6 +320,10 @@ export default {
                 .item
                     color: #2A65B7
                     font-weight: 200
+                    svg
+                        width: 20px
+                        height: 20px
+                        fill: #2A65B7
         .actions
             align-items: center
             display: flex

--- a/src/components/parts/GeneAssociationsCard.vue
+++ b/src/components/parts/GeneAssociationsCard.vue
@@ -60,11 +60,16 @@
                     </a>
                 </span>
                 <span
-                    @click="showMorePhenotypes = true"
+                    @click="showMorePhenotypes = !showMorePhenotypes"
                     class="additional-information phenotypes"
-                    v-if="inPatientPhens(gene.phenotypes).nonAssociatedPhens.length > 0 && !showMorePhenotypes"
-                    >Show {{ inPatientPhens(gene.phenotypes).nonAssociatedPhens.length }} Additional Phenotypes</span
-                >
+                    v-if="inPatientPhens(gene.phenotypes).nonAssociatedPhens.length > 0">
+                    <span v-if="!showMorePhenotypes"
+                        >Show {{ inPatientPhens(gene.phenotypes).nonAssociatedPhens.length }} Additional Phenotypes</span
+                    >
+                    <span v-else
+                        >Hide {{ inPatientPhens(gene.phenotypes).nonAssociatedPhens.length }} non-patient Phenotypes</span
+                    >
+                </span>
             </p>
 
             <p class="inner-column" v-if="gene.diseases && Object.keys(gene.diseases).length > 0">
@@ -132,7 +137,7 @@ export default {
         numOverlappedByGene(gene) {
             if (this.patientPhenotypes && this.patientPhenotypes.length > 0) {
                 let inCommonPhens = Object.keys(gene.phenotypes).filter((phenotype) =>
-                    this.patientPhenotypes.includes(phenotype)
+                    this.patientPhenotypes.includes(phenotype),
                 );
                 return inCommonPhens.length;
             } else {


### PR DESCRIPTION
#136 
This pull request includes several changes to the `src/components/LowerModal.vue` and `src/components/parts/GeneAssociationsCard.vue` files to improve the user interface and functionality related to displaying genetic variant information. The key changes include the addition of new computed properties for sorting genes, the introduction of a toggle feature for displaying additional gene information, and various updates to the template and style sections.

Improvements to gene display and sorting:

* Added computed properties `sortedRelevantGenes` and `sortedIrrelevantGenes` to sort genes based on their relevance to patient phenotypes and diseases.
* Introduced a `hideExtraGeneInfo` data property to control the visibility of additional gene information, with a corresponding toggle button in the template. [[1]](diffhunk://#diff-7633096374d014d0a26f507f1a32c1e304a09d80c93d35bd1dbd587110b3f28dR127) [[2]](diffhunk://#diff-7633096374d014d0a26f507f1a32c1e304a09d80c93d35bd1dbd587110b3f28dL62-R103)

Template updates:

* Replaced genotype display with SVG representation using `svgForZygosity` method.
* Updated the message for no overlapping structural variants (SVs) found to improve clarity.

Style enhancements:

* Added styles for SVG elements and new classes for gene card rows and show more genes button. [[1]](diffhunk://#diff-7633096374d014d0a26f507f1a32c1e304a09d80c93d35bd1dbd587110b3f28dR411-R414) [[2]](diffhunk://#diff-7633096374d014d0a26f507f1a32c1e304a09d80c93d35bd1dbd587110b3f28dL338-R429) [[3]](diffhunk://#diff-7633096374d014d0a26f507f1a32c1e304a09d80c93d35bd1dbd587110b3f28dR448-R467)

GeneAssociationsCard component updates:

* Modified the click behavior for showing additional phenotypes to toggle visibility instead of only showing.
* Fixed a minor issue with the `numOverlappedByGene` method to ensure proper filtering of phenotypes.